### PR TITLE
Исправление несоответствия названий методов компонента DIgitalOut

### DIFF
--- a/compiler/library/ArduinoMicro/1.0/source/DigitalOut.h
+++ b/compiler/library/ArduinoMicro/1.0/source/DigitalOut.h
@@ -4,8 +4,8 @@
 class DigitalOut {
     public:
         DigitalOut(uint8_t _pin);
-        void on();
-        void off();
+        void high();
+        void low();
         void init();
         void toggle();
 

--- a/compiler/library/ArduinoMicro/1.0/source/DigitalOut.ino
+++ b/compiler/library/ArduinoMicro/1.0/source/DigitalOut.ino
@@ -5,14 +5,12 @@ DigitalOut::DigitalOut(uint8_t _pin) {
     value = LOW;
 }
 
-//
-void DigitalOut::on() {
+void DigitalOut::high() {
     digitalWrite(pin, HIGH);
     value = HIGH;
 }
 
-//
-void DigitalOut::off() {
+void DigitalOut::low() {
     digitalWrite(pin, LOW);
     value = LOW;
 }

--- a/compiler/library/ArduinoUno/1.0/source/DigitalOut.h
+++ b/compiler/library/ArduinoUno/1.0/source/DigitalOut.h
@@ -4,8 +4,8 @@
 class DigitalOut {
     public:
         DigitalOut(uint8_t _pin);
-        void on();
-        void off();
+        void low();
+        void high();
         void init();
         void toggle();
 

--- a/compiler/library/ArduinoUno/1.0/source/DigitalOut.ino
+++ b/compiler/library/ArduinoUno/1.0/source/DigitalOut.ino
@@ -5,14 +5,12 @@ DigitalOut::DigitalOut(uint8_t _pin) {
     value = LOW;
 }
 
-//
-void DigitalOut::on() {
+void DigitalOut::high() {
     digitalWrite(pin, HIGH);
     value = HIGH;
 }
 
-//
-void DigitalOut::off() {
+void DigitalOut::low() {
     digitalWrite(pin, LOW);
     value = LOW;
 }


### PR DESCRIPTION
В платформе методы назывались low и high, но были реализованы как методы off и on