### PR TITLE
Движок МС: фикс перехода в родительское состояние

### DIFF
--- a/compiler/library/default/1.0/source/qhsm.c
+++ b/compiler/library/default/1.0/source/qhsm.c
@@ -1,4 +1,4 @@
-#include "qhsm.hpp"
+#include "qhsm.h"
 
 #include <stddef.h>
 

--- a/compiler/library/default/1.0/source/qhsm.c
+++ b/compiler/library/default/1.0/source/qhsm.c
@@ -1,4 +1,4 @@
-#include "qhsm.h"
+#include "qhsm.hpp"
 
 #include <stddef.h>
 
@@ -44,23 +44,26 @@ static void do_transition(QHsm *me)
     ptrdiff_t lca = -1;
 
     path[0] = target;
-
+    // Формируем путь от текущего состояния до самого дальнего родителя
     while (target != &QHsm_top) {
         target(me, &standard_events[QEP_EMPTY_SIG_]);
         target = me->effective_;
         path[++top] = target;
 
-        if (target == source) {
+        if (target == source) { // Если вышли на самих себя, то выходим?
             lca = top;
             break;
         }
     }
 
     while (lca == -1) {
+        // Выходим из состояний.
         source(me, &standard_events[Q_EXIT_SIG]);
         source(me, &standard_events[QEP_EMPTY_SIG_]);
         source = me->effective_;
 
+        // Если текущее состояние является родителем, то выходим из цикла
+        // Пока не вижу ситуаций, когда мы делаем в этом цикле больше одной итерации
         for (ptrdiff_t i = 0; i <= top; ++i) {
             if (path[i] == source) {
                 lca = i;
@@ -70,6 +73,10 @@ static void do_transition(QHsm *me)
     }
 
     target = path[lca];
+
+    if (lca == 0) {
+        target(me, &standard_events[Q_ENTRY_SIG]);
+    }
 
     for (ptrdiff_t i = lca - 1; i >= 0; --i) {
         target = path[i];

--- a/compiler/library/default/1.0/source/qhsm.cpp
+++ b/compiler/library/default/1.0/source/qhsm.cpp
@@ -44,23 +44,26 @@ static void do_transition(QHsm *me)
     ptrdiff_t lca = -1;
 
     path[0] = target;
-
+    // Формируем путь от текущего состояния до самого дальнего родителя
     while (target != &QHsm_top) {
         target(me, &standard_events[QEP_EMPTY_SIG_]);
         target = me->effective_;
         path[++top] = target;
 
-        if (target == source) {
+        if (target == source) { // Если вышли на самих себя, то выходим?
             lca = top;
             break;
         }
     }
 
     while (lca == -1) {
+        // Выходим из состояний.
         source(me, &standard_events[Q_EXIT_SIG]);
         source(me, &standard_events[QEP_EMPTY_SIG_]);
         source = me->effective_;
 
+        // Если текущее состояние является родителем, то выходим из цикла
+        // Пока не вижу ситуаций, когда мы делаем в этом цикле больше одной итерации
         for (ptrdiff_t i = 0; i <= top; ++i) {
             if (path[i] == source) {
                 lca = i;
@@ -70,6 +73,10 @@ static void do_transition(QHsm *me)
     }
 
     target = path[lca];
+
+    if (lca == 0) {
+        target(me, &standard_events[Q_ENTRY_SIG]);
+    }
 
     for (ptrdiff_t i = lca - 1; i >= 0; --i) {
         target = path[i];

--- a/examples/test_parent_transitions.graphml
+++ b/examples/test_parent_transitions.graphml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <data key="gFormat">Cyberiada-GraphML-1.0</data>
+  <key attr.name="name" attr.type="string" for="node" id="dName"></key>
+  <key attr.name="data" attr.type="string" for="node" id="dData"></key>
+  <key attr.name="data" attr.type="string" for="edge" id="dData"></key>
+  <key attr.name="initial" attr.type="string" for="node" id="dInitial"></key>
+  <key for="edge" id="dGeometry"></key>
+  <key for="node" id="dGeometry"></key>
+  <key for="edge" id="dColor"></key>
+  <key for="node" id="dNote"></key>
+  <key for="node" id="dColor"></key>
+  <graph id="MS1Lamp1">
+    <data key="dStateMachine"></data>
+    <data key="dGeometry">
+      <rect x="0" y="0" width="450" height="100"></rect>
+    </data>
+    <node id="coreMeta">
+      <data key="dNote">formal</data>
+      <data key="dName">CGML_META</data>
+      <data key="dData">standardVersion/ 1.0
+
+platformVersion/ 1.0
+
+lapkiVisual/ true
+
+platform/ tjc-ms1-lmp-a3
+
+</data>
+    </node>
+    <node id="opffyasscvvpicxlhzet">
+      <data key="dName">Начальное</data>
+      <data key="dData">entry/
+LED1.on();
+LED2.on();
+LED3.on();
+Timer1.start(2000);
+
+</data>
+      <data key="dGeometry">
+        <rect x="101.71478271484375" y="204.75005340576172" width="450" height="100"></rect>
+      </data>
+    </node>
+    <node id="gkymncckchgzqwhfsyfd">
+      <data key="dName">Родительское</data>
+      <data key="dData">entry/
+LED1.off();
+LED2.off();
+LED3.off();
+Timer2.start(1000);
+Timer1.disable();
+
+</data>
+      <data key="dGeometry">
+        <rect x="114.4295654296875" y="502.50010681152344" width="450" height="100"></rect>
+      </data>
+      <graph id="gkymncckchgzqwhfsyfd">
+        <node id="iwautgzajohiggsbvxvf">
+          <data key="dName">Лампочка 1</data>
+          <data key="dData">entry/
+LED1.on();
+
+</data>
+          <data key="dGeometry">
+            <rect x="43.72000000000001" y="289.8000000000002" width="450" height="100"></rect>
+          </data>
+        </node>
+        <node id="zippnzlkilhmmckanmvv">
+          <data key="dName">Лампочка 2</data>
+          <data key="dData">entry/
+LED2.on();
+
+</data>
+          <data key="dGeometry">
+            <rect x="83" y="448" width="450" height="100"></rect>
+          </data>
+        </node>
+        <node id="wydsgxxupcepcbtpvffm">
+          <data key="dName">Лампочка 3</data>
+          <data key="dData">entry/
+LED3.on();
+
+</data>
+          <data key="dGeometry">
+            <rect x="738.0400000000021" y="223.7200000000001" width="450" height="100"></rect>
+          </data>
+        </node>
+        <node id="mxmbeegeevcftekigiyv">
+          <data key="dVertex">initial</data>
+          <data key="dGeometry">
+            <point x="48.99999999999999" y="172.12000000000006"></point>
+          </data>
+        </node>
+      </graph>
+    </node>
+    <node id="nvazmnxhujnqwpbbijhx">
+      <data key="dVertex">initial</data>
+      <data key="dGeometry">
+        <point x="1.71478271484375" y="184.75005340576172"></point>
+      </data>
+    </node>
+    <node id="cLED1">
+      <data key="dNote">formal</data>
+      <data key="dName">CGML_COMPONENT</data>
+      <data key="dData">id/ LED1
+
+type/ LED
+
+pin/ 1
+
+</data>
+      <data key="dLapkiSchemePosition">
+        <point x="30" y="30"></point>
+      </data>
+    </node>
+    <node id="cLED2">
+      <data key="dNote">formal</data>
+      <data key="dName">CGML_COMPONENT</data>
+      <data key="dData">id/ LED2
+
+type/ LED
+
+pin/ 2
+
+</data>
+      <data key="dLapkiSchemePosition">
+        <point x="30" y="30"></point>
+      </data>
+    </node>
+    <node id="cLED3">
+      <data key="dNote">formal</data>
+      <data key="dName">CGML_COMPONENT</data>
+      <data key="dData">id/ LED3
+
+type/ LED
+
+pin/ 3
+
+</data>
+      <data key="dLapkiSchemePosition">
+        <point x="30" y="30"></point>
+      </data>
+    </node>
+    <node id="cTimer1">
+      <data key="dNote">formal</data>
+      <data key="dName">CGML_COMPONENT</data>
+      <data key="dData">id/ Timer1
+
+type/ Timer
+
+</data>
+      <data key="dLapkiSchemePosition">
+        <point x="30" y="30"></point>
+      </data>
+    </node>
+    <node id="cTimer2">
+      <data key="dNote">formal</data>
+      <data key="dName">CGML_COMPONENT</data>
+      <data key="dData">id/ Timer2
+
+type/ Timer
+
+</data>
+      <data key="dLapkiSchemePosition">
+        <point x="30" y="30"></point>
+      </data>
+    </node>
+    <edge id="mwiltsjxobjyfpumybfi" source="nvazmnxhujnqwpbbijhx" target="opffyasscvvpicxlhzet"></edge>
+    <edge id="otddlgxsbahqvvkbzfnm" source="opffyasscvvpicxlhzet" target="gkymncckchgzqwhfsyfd">
+      <data key="dData">Timer1.timeout/
+
+</data>
+      <data key="dLabelGeometry">
+        <point x="234.15217407226564" y="394.62508010864263"></point>
+      </data>
+    </edge>
+    <edge id="ttvhcicfygmlsphpmfns" source="mxmbeegeevcftekigiyv" target="iwautgzajohiggsbvxvf"></edge>
+    <edge id="wclddnqlmqvdfnjcgmmf" source="iwautgzajohiggsbvxvf" target="zippnzlkilhmmckanmvv">
+      <data key="dData">Timer2.timeout/
+LED1.off();
+
+</data>
+      <data key="dLabelGeometry">
+        <point x="621.6400000000008" y="741.0799999999996"></point>
+      </data>
+    </edge>
+    <edge id="mbdwdqaioqzlatyspwoc" source="zippnzlkilhmmckanmvv" target="wydsgxxupcepcbtpvffm">
+      <data key="dData">Timer2.timeout/
+LED2.off();
+
+</data>
+      <data key="dLabelGeometry">
+        <point x="718.5" y="958.5"></point>
+      </data>
+    </edge>
+    <edge id="szeuvsntoetisftiycji" source="wydsgxxupcepcbtpvffm" target="gkymncckchgzqwhfsyfd">
+      <data key="dData">Timer2.timeout/
+
+</data>
+      <data key="dLabelGeometry">
+        <point x="1368.0347827148455" y="541.9500534057627"></point>
+      </data>
+    </edge>
+  </graph>
+</graphml>

--- a/test/test_cgml.py
+++ b/test/test_cgml.py
@@ -168,6 +168,11 @@ async def test_generating_code():
         'tjc-ms1-lmp-a3',
         'compiler/platforms/tjc-ms1-lmp-a3/1.0/tjc-ms1-lmp-a3-1.0.json'
     ),
+    pytest.param(
+        'examples/test_parent_transitions.graphml',
+        'tjc-ms1-lmp-a3',
+        'compiler/platforms/tjc-ms1-lmp-a3/1.0/tjc-ms1-lmp-a3-1.0.json'
+    ),
 ])
 @pytest.mark.asyncio
 async def test_compile_schemes(scheme_path: str,


### PR DESCRIPTION
Если совершается переход в ближайшего родителя, то в функции `do_transition`  мы не входим в цикл с вызовом сигнала `Q_ENTRY_SIG`, так как в таком случае lca у нас равно нулю.

```cpp
    for (ptrdiff_t i = lca - 1; i >= 0; --i) {
        target = path[i];
        target(me, &standard_events[Q_ENTRY_SIG]);
    }
```
Фиксится это простой проверкой:
```cpp
    if (lca == 0) {
        target(me, &standard_events[Q_ENTRY_SIG]);
    }
```