### PR TITLE
Фикс получения расширения бинарных файлов

### DIFF
--- a/compiler/handler.py
+++ b/compiler/handler.py
@@ -106,7 +106,7 @@ async def create_response(
                     response.binary.append(
                         File(
                             filename=path.name.split('.')[0],
-                            extension=''.join(path.suffixes),
+                            extension=''.join(path.suffixes)[1:],
                             fileContent=b64_data.decode('ascii'),
                         )
                     )


### PR DESCRIPTION
Перед расширением бинарного файла добавлялась точка, например, `.bin`, хотя на клиенте ожидается `bin`