### PR TITLE
(Arduino UNO) Компонент lcd по i2c

### DIFF
--- a/compiler/library/ArduinoUno/1.0/source/LCD_I2C.cpp
+++ b/compiler/library/ArduinoUno/1.0/source/LCD_I2C.cpp
@@ -1,0 +1,318 @@
+/*
+    LCD_I2C - Arduino library to control a 16x2 LCD via an I2C adapter based on PCF8574
+    * 2021-11-18 Brewmanz: make changes to also work for 20x4 LCD2004
+
+    Copyright(C) 2020 Blackhack <davidaristi.0504@gmail.com>
+
+    This program is free software : you can redistribute it and /or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.If not, see < https://www.gnu.org/licenses/>.
+*/
+
+#include "LCD_I2C.h"
+#include "Wire.h"
+
+LCD_I2C::LCD_I2C(TwoWire& wire, uint8_t address, uint8_t columns, uint8_t rows)
+    : _wire(wire) // Use the TwoWire object passed as parameter.
+    , _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00)
+{
+}
+
+LCD_I2C::LCD_I2C(uint8_t address, uint8_t columns, uint8_t rows)
+    : _wire(Wire) // Use the default object 'Wire'.
+    , _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00)
+{
+}
+
+void LCD_I2C::begin(int sdaPin, int sclPin, bool beginWire)
+{
+#if defined (ESP32)
+    // ESP32 requires setting sda and scl pins.
+    _wire.setPins(sdaPin, sclPin);
+#endif
+    begin(beginWire);
+}
+
+void LCD_I2C::begin(bool beginWire)
+{
+
+    if (beginWire)
+        _wire.begin();
+
+    I2C_Write(0b00000000); // Clear i2c adapter
+    delay(50); //Wait more than 40ms after powerOn.
+
+    InitializeLCD();
+}
+
+void LCD_I2C::backlight()
+{
+    _output.Led = 1;
+    I2C_Write(0b00000000 | _output.Led << 3); // Led pin is independent from LCD data and control lines.
+}
+
+void LCD_I2C::noBacklight()
+{
+    _output.Led = 0;
+    I2C_Write(0b00000000 | _output.Led << 3); // Led pin is independent from LCD data and control lines.
+}
+
+void LCD_I2C::clear()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    LCD_WriteByte(0b00000001);
+    delayMicroseconds(1600);
+}
+
+void LCD_I2C::home()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    LCD_WriteByte(0b00000010);
+    delayMicroseconds(1600);
+}
+
+// Part of Entry mode set
+void LCD_I2C::leftToRight()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _entryState |= 1 << 1;
+
+    LCD_WriteByte(0b00000100 | _entryState);
+    delayMicroseconds(37);
+}
+
+// Part of Entry mode set
+void LCD_I2C::rightToLeft()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _entryState &= ~(1 << 1);
+
+    LCD_WriteByte(0b00000100 | _entryState);
+    delayMicroseconds(37);
+}
+
+// Part of Entry mode set
+void LCD_I2C::autoscroll()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _entryState |= 1;
+
+    LCD_WriteByte(0b00000100 | _entryState);
+    delayMicroseconds(37);
+}
+
+// Part of Entry mode set
+void LCD_I2C::noAutoscroll()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _entryState &= ~1;
+
+    LCD_WriteByte(0b00000100 | _entryState);
+    delayMicroseconds(37);
+}
+
+// Part of Display control
+void LCD_I2C::display()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _displayState |= 1 << 2;
+
+    LCD_WriteByte(0b00001000 | _displayState);
+    delayMicroseconds(37);
+}
+
+// Part of Display control
+void LCD_I2C::noDisplay()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _displayState &= ~(1 << 2);
+
+    LCD_WriteByte(0b00001000 | _displayState);
+    delayMicroseconds(37);
+}
+
+// Part of Display control
+void LCD_I2C::cursor()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _displayState |= 1 << 1;
+
+    LCD_WriteByte(0b00001000 | _displayState);
+    delayMicroseconds(37);
+}
+
+// Part of Display control
+void LCD_I2C::noCursor()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _displayState &= ~(1 << 1);
+
+    LCD_WriteByte(0b00001000 | _displayState);
+    delayMicroseconds(37);
+}
+
+// Part of Display control
+void LCD_I2C::blink()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _displayState |= 1;
+
+    LCD_WriteByte(0b00001000 | _displayState);
+    delayMicroseconds(37);
+}
+
+// Part of Display control
+void LCD_I2C::noBlink()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    _displayState &= ~1;
+
+    LCD_WriteByte(0b00001000 | _displayState);
+    delayMicroseconds(37);
+}
+
+// Part of Cursor or display shift
+void LCD_I2C::scrollDisplayLeft()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    LCD_WriteByte(0b00011000);
+    delayMicroseconds(37);
+}
+
+// Part of Cursor or display shift
+void LCD_I2C::scrollDisplayRight()
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    LCD_WriteByte(0b00011100);
+    delayMicroseconds(37);
+}
+
+// Set CGRAM address
+void LCD_I2C::createChar(uint8_t location, uint8_t charmap[])
+{
+    _output.rs = 0;
+    _output.rw = 0;
+
+    location %= 8;
+
+    LCD_WriteByte(0b01000000 | (location << 3));
+    delayMicroseconds(37);
+
+    for (int i = 0; i < 8; i++)
+        write(charmap[i]);
+
+    setCursor(0, 0); // Set the address pointer back to the DDRAM
+}
+
+// Set DDRAM address
+void LCD_I2C::setCursor(uint8_t col, uint8_t row)
+{
+    static const uint8_t row_offsets[] = {0x00, 0x40, 0x14, 0x54};
+    _output.rs = 0;
+    _output.rw = 0;
+
+    if(col > _columnMax) { col = _columnMax; } // sanity limits
+    if(row > _rowMax) { row = _rowMax; } // sanity limits
+
+    const uint8_t newAddress = row_offsets[row] + col;
+
+    LCD_WriteByte(0b10000000 | newAddress);
+    delayMicroseconds(37);
+}
+
+size_t LCD_I2C::write(uint8_t character)
+{
+    _output.rs = 1;
+    _output.rw = 0;
+
+    LCD_WriteByte(character);
+    delayMicroseconds(41);
+
+    return 1;
+}
+
+void LCD_I2C::InitializeLCD()
+{
+    // See HD44780U datasheet "Initializing by Instruction" Figure 24 (4-Bit Interface)
+    _output.rs = 0;
+    _output.rw = 0;
+
+    LCD_WriteHighNibble(0b00110000);
+    delayMicroseconds(4200);
+    LCD_WriteHighNibble(0b00110000);
+    delayMicroseconds(150);
+    LCD_WriteHighNibble(0b00110000);
+    delayMicroseconds(37);
+    LCD_WriteHighNibble(0b00100000); // Function Set - 4 bits mode
+    delayMicroseconds(37);
+    LCD_WriteByte(0b00101000); // Function Set - 4 bits(Still), 2 lines, 5x8 font
+    delayMicroseconds(37);
+
+    display();
+    clear();
+    leftToRight();
+}
+
+void LCD_I2C::I2C_Write(uint8_t output)
+{
+    _wire.beginTransmission(_address);
+    _wire.write(output);
+    _wire.endTransmission();
+}
+
+void LCD_I2C::LCD_WriteHighNibble(uint8_t output)
+{
+    I2C_Write(_output.getHighData(output, true));
+    delayMicroseconds(1); // High part of enable should be >450 nS
+    I2C_Write(_output.getHighData(output, false));
+}
+
+void LCD_I2C::LCD_WriteByte(uint8_t output)
+{
+    LCD_WriteHighNibble(output);
+    delayMicroseconds(37); // I think we need a delay between half byte writes, but no sure how long it needs to be.
+
+    I2C_Write(_output.getLowData(output, true));
+    delayMicroseconds(1); // High part of enable should be >450 nS
+    I2C_Write(_output.getLowData(output, false));
+
+    //delayMicroseconds(37); // Some commands have different timing requirement,
+                             // so every command should handle its own delay after execution
+}

--- a/compiler/library/ArduinoUno/1.0/source/LCD_I2C.h
+++ b/compiler/library/ArduinoUno/1.0/source/LCD_I2C.h
@@ -1,0 +1,137 @@
+/*
+    LCD_I2C - Arduino library to control a 16x2 LCD via an I2C adapter based on PCF8574
+    * 2021-11-18 Brewmanz: make changes to also work for 20x4 LCD2004
+
+    Copyright(C) 2020 Blackhack <davidaristi.0504@gmail.com>
+
+    This program is free software : you can redistribute it and /or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.If not, see < https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifndef _LCD_I2C_h
+#define _LCD_I2C_h
+
+#include "Arduino.h"
+
+/**
+ * TwoWire class declaration is required for optionally using Wire1, Wire2.. objects
+ * for I2C interface.
+ * Forward declaration of TwoWire avoids include of Wire.h here and in user sketch.
+ */
+#ifdef ARDUINO_ARCH_MBED
+// Special handling for Mbed platforms required.
+namespace arduino {class MbedI2C;}
+typedef arduino::MbedI2C TwoWire;
+#else
+class TwoWire;
+#endif
+
+class LCD_I2C : public Print
+{
+public:
+    /**
+     * This constructor just uses the default TwoWire object 'Wire'.
+     */
+    LCD_I2C(uint8_t address, uint8_t columns = 16, uint8_t rows = 2);
+
+    /**
+     * This constructor takes a TwoWire object so that the driver can
+     * work on another interface.
+     * In case that the hardware has a second TwoWire interface
+     * which should be used for the LCD, just pass 'Wire1' as the
+     * first parameter. For the 3rd interface use 'Wire2', and so on.
+     *
+     * There is no need for the sketch to include the Wire.h header.
+     * Just declare the other TwoWire object to be used as 'extern'.
+     *
+     * Example:
+     *  #include <LCD_I2C.h>
+     *  extern TwoWire Wire1;
+     *  LCD_I2C(Wire1, 0x27, 16, 2);
+     *
+     */
+    LCD_I2C(TwoWire& wire, uint8_t address, uint8_t columns = 16, uint8_t rows = 2);
+
+    /**
+     * Some microcontrollers (like ESP32) require to set sda pin and
+     * scl pin for I2C.
+     */
+    void begin(int sdaPin, int sclPin, bool beginWire = true);
+
+    void begin(bool beginWire = true);
+    void backlight();
+    void noBacklight();
+
+    void clear();
+    void home();
+    void leftToRight();
+    void rightToLeft();
+    void autoscroll();
+    void noAutoscroll();
+    void display();
+    void noDisplay();
+    void cursor();
+    void noCursor();
+    void blink();
+    void noBlink();
+    void scrollDisplayLeft();
+    void scrollDisplayRight();
+    void createChar(uint8_t location, uint8_t charmap[]);
+    void setCursor(uint8_t col, uint8_t row);
+
+    // Method used by the Arduino class "Print" which is the one that provides the .print(string) method
+    size_t write(uint8_t character) override;
+
+private:
+    void InitializeLCD();
+    void I2C_Write(uint8_t output);
+    void LCD_WriteByte(uint8_t output);
+    inline void LCD_WriteHighNibble(uint8_t output);
+
+private:
+    TwoWire& _wire;
+    const uint8_t _address;
+    const uint8_t _columnMax; // Last valid column index. Note the column index starts at zero.
+    const uint8_t _rowMax;    // Last valid row index. Note the row index starts at zero.
+    uint8_t _displayState;
+    uint8_t _entryState;
+
+    /* This struct helps us constructing the I2C output based on data and control outputs.
+       Because the LCD is set to 4-bit mode, 4 bits of the I2C output are for the control outputs
+       while the other 4 bits are for the 8 bits of data which are send in parts using the enable output.*/
+    struct OutputState
+    {
+        uint8_t rs = 0;
+        uint8_t rw = 0;
+        uint8_t Led = 0;
+
+        uint8_t getLowData(uint8_t data, uint8_t E) const
+        {
+            return getCommonData(E) | ((data & 0x0F) << 4);
+        }
+
+        uint8_t getHighData(uint8_t data, uint8_t E) const
+        {
+            return getCommonData(E) | (data & 0xF0);
+        }
+
+    private:
+        inline uint8_t getCommonData(uint8_t E) const {
+            return rs | (rw << 1) | (E << 2) | (Led << 3);
+        }
+    } _output;
+};
+
+#endif // #ifndef _LCD_I2C_h

--- a/compiler/library/ArduinoUno/1.0/source/Lcd.h
+++ b/compiler/library/ArduinoUno/1.0/source/Lcd.h
@@ -1,0 +1,37 @@
+#ifndef LCD_H
+#define LCD_H
+
+#include <Print.h>
+
+#include "LCD_I2C.h"
+
+class Lcd : public Print {
+    LCD_I2C lcd_;
+    uint8_t cols_;
+    uint8_t rows_;
+    bool isOverflowed_ = 0;
+    uint8_t emptyCount_;
+
+   public:
+   const uint8_t& emptyCount = emptyCount_;
+    Lcd(uint8_t address, uint8_t cols = 16, uint8_t rows = 2)
+        : lcd_(address, cols, rows),
+          cols_(cols),
+          rows_(rows),
+          emptyCount_(rows * cols) {}
+
+    void init();
+
+    virtual size_t write(uint8_t c) override;
+
+    void reset();
+
+    void setCursor(uint8_t col, uint8_t row);
+
+    void backlight();
+
+    void noBacklight();
+
+};
+
+#endif

--- a/compiler/library/ArduinoUno/1.0/source/lcd.cpp
+++ b/compiler/library/ArduinoUno/1.0/source/lcd.cpp
@@ -1,0 +1,30 @@
+#include "Lcd.h"
+
+#include <ctype.h>
+
+void Lcd::init() {
+    lcd_.begin();
+    lcd_.backlight();
+}
+
+size_t Lcd::write(uint8_t c) {
+    return lcd_.write(c);
+};
+
+void Lcd::reset() {
+    lcd_.home();
+    lcd_.clear();
+}
+
+void Lcd::setCursor(uint8_t col, uint8_t row){
+    lcd_.setCursor(col, row); //verification is inside
+}
+
+void Lcd::backlight() {
+    lcd_.backlight();
+}
+
+void Lcd::noBacklight() {
+    lcd_.noBacklight();
+}
+

--- a/compiler/platforms/ArduinoUno/1.0/ArduinoUno-1.0.json
+++ b/compiler/platforms/ArduinoUno/1.0/ArduinoUno-1.0.json
@@ -1043,6 +1043,83 @@
           "description": "Размер массива."
         }
       }
+    },
+    "Lcd": {
+      "description": "Класс-надстройка над LCD. Вызывает сигналы при получении данных.",
+      "img": "",
+      "signals": {},
+      "initializationParameters": {},
+      "constructorParameters": {
+        "address": {
+          "type": "uint8_t",
+          "name": "адрес",
+          "description": "I2C адрес дисплея"
+        },
+        "cols": {
+          "type": "uint8_t",
+          "name": "число столбцов",
+          "description": ""
+        },
+        "rows": {
+          "type": "uint8_t",
+          "name": "число строк",
+          "description": ""
+        }
+      },
+      "initializationFunction": "init",
+      "methods": {
+        "print": {
+          "alias": "Вывод",
+          "img": "arduino/print.svg",
+          "description": "Вывести данные на дисплей",
+          "parameters": [
+            {
+              "name": "Сообщение",
+              "description": "Данные для вывода",
+              "type": "int | char[]"
+            }
+          ]
+        },
+        "setCursor": {
+          "alias": "Задать позицию",
+          "img": "",
+          "description": "Устанавливает курсор в новую позиция так, что распечатанный текст будет выводиться с этой позиции",
+          "parameters": [
+            {
+              "name": "столбец",
+              "description": "",
+              "type": "int"
+            },
+            {
+              "name": "строка",
+              "description": "",
+              "type": "int"
+            }
+          ]
+        },
+        "reset": {
+          "alias": "Сброс",
+          "img": "",
+          "description": "Очистить дисплей",
+          "parameters": []
+        },
+        "backlight":{
+          "alias": "Включить подсветку",
+          "img": "",
+          "description": "Включает подсветку дисплея",
+          "parameters": []
+        },
+        "noBacklight":{
+          "alias": "Выключить подсветку",
+          "img": "",
+          "description": "Выключает подсветку дисплея",
+          "parameters": []
+        }
+      },
+      "variables": {},
+      "buildFiles": ["LCD_I2C.cpp", "Lcd.cpp", "LCD_I2C.h", "Lcd.h"],
+      "importFiles": ["LCD_I2C.h", "Lcd.h"],
+      "singletone": false
     }
   }
 }

--- a/compiler/platforms/ArduinoUno/1.0/ArduinoUno-1.0.json
+++ b/compiler/platforms/ArduinoUno/1.0/ArduinoUno-1.0.json
@@ -1045,7 +1045,8 @@
       }
     },
     "Lcd": {
-      "description": "Класс-надстройка над LCD. Вызывает сигналы при получении данных.",
+      "name": "Lcd",
+      "description": "Компонент для работы с lcd 1602 по i2c",
       "img": "",
       "signals": {},
       "initializationParameters": {},
@@ -1087,12 +1088,12 @@
           "parameters": [
             {
               "name": "столбец",
-              "description": "",
+              "description": "нумерация столбцов с нуля",
               "type": "int"
             },
             {
               "name": "строка",
-              "description": "",
+              "description": "нумерация строк с нуля",
               "type": "int"
             }
           ]


### PR DESCRIPTION
Добавил поддержку символьных дисплеев lcd 1602, подключающихся по i2c

За основу взята библиотека от [blackhack](https://github.com/blackhack/LCD_I2C)

[Ссылка на пример такого дисплея](https://www.chipdip.ru/product/spi-i2c-1602-lcd-blue-zhki-displey-16-h-2-s-posledovatelnym-9000415299)